### PR TITLE
fix: upgrade nodemailer to ^7.0.11 to fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "mailisk",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mailisk",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.1.2",
-        "nodemailer": "^6.8.0"
+        "nodemailer": "^7.0.11"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/nodemailer": "^6.4.6",
+        "@types/nodemailer": "^7.0.11",
         "dotenv": "^16.4.7",
         "jest": "^29.7.0",
         "jest-mock-axios": "^4.8.0",
@@ -68,6 +68,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1089,10 +1090,11 @@
       "dev": true
     },
     "node_modules/@types/nodemailer": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.6.tgz",
-      "integrity": "sha512-pD6fL5GQtUKvD2WnPmg5bC2e8kWCAPDwMPmHe/ohQbW+Dy0EcHgZ2oCSuPlWNqk74LS5BVMig1SymQbFMPPK3w==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1396,6 +1398,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -1857,6 +1860,7 @@
       "integrity": "sha512-N7wBhfJ/E5fzn/SpNgX+oW2RLRjwaL8Y0ezqNqhjD6w0H2p0rDuEz2FKZqpqLnO8DCaWumKe8dsC/ljvVSSxng==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2881,6 +2885,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3779,9 +3784,10 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.8.0.tgz",
-      "integrity": "sha512-EjYvSmHzekz6VNkNd12aUqAco+bOkRe3Of5jVhltqKhEsjw/y0PYPJfp83+s9Wzh1dspYAkUW/YNQ350NATbSQ==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4700,6 +4706,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4936,6 +4943,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -5672,9 +5680,9 @@
       "dev": true
     },
     "@types/nodemailer": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.6.tgz",
-      "integrity": "sha512-pD6fL5GQtUKvD2WnPmg5bC2e8kWCAPDwMPmHe/ohQbW+Dy0EcHgZ2oCSuPlWNqk74LS5BVMig1SymQbFMPPK3w==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -5901,6 +5909,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
       "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -6194,6 +6203,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.10.tgz",
       "integrity": "sha512-N7wBhfJ/E5fzn/SpNgX+oW2RLRjwaL8Y0ezqNqhjD6w0H2p0rDuEz2FKZqpqLnO8DCaWumKe8dsC/ljvVSSxng==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@esbuild/android-arm": "0.15.10",
         "@esbuild/linux-loong64": "0.15.10",
@@ -6823,6 +6833,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7481,9 +7492,9 @@
       "dev": true
     },
     "nodemailer": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.8.0.tgz",
-      "integrity": "sha512-EjYvSmHzekz6VNkNd12aUqAco+bOkRe3Of5jVhltqKhEsjw/y0PYPJfp83+s9Wzh1dspYAkUW/YNQ350NATbSQ=="
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -8059,7 +8070,8 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/nodemailer": "^6.4.6",
+    "@types/nodemailer": "^7.0.11",
     "dotenv": "^16.4.7",
     "jest": "^29.7.0",
     "jest-mock-axios": "^4.8.0",
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "axios": "^1.1.2",
-    "nodemailer": "^6.8.0"
+    "nodemailer": "^7.0.11"
   }
 }


### PR DESCRIPTION
## Summary

Upgrades `nodemailer` from `^6.8.0` to `^7.0.11` to fix two security vulnerabilities:

### 1. Email to unintended domain due to Interpretation Conflict
The email parsing library incorrectly handles quoted local-parts containing `@`, leading to misrouting of email recipients where the parser extracts and routes to an unintended domain instead of the RFC-compliant target.
- **Affected versions:** `< 7.0.7`
- **Patched version:** `7.0.7`

### 2. DoS via recursive calls in addressparser
Nodemailer's address parser does not enforce recursion depth limits for nested group structures. A malicious input with many colons (e.g., `g0: g1: g2: ... gN: victim@example.com;`) causes infinite recursion, throwing `Maximum call stack size exceeded` and crashing the process. A single request is enough to shut down the service.
- **Affected versions:** `<= 7.0.10`
- **Patched version:** `7.0.11`

## Changes
- Updated `nodemailer` from `^6.8.0` to `^7.0.11` in `dependencies` (resolves to `7.0.13`)
- Updated `@types/nodemailer` from `^6.4.6` to `^7.0.11` in `devDependencies`
- Regenerated `package-lock.json`

## Verification
- ✅ Build succeeds (CJS + ESM + DTS)
- ✅ All 23 tests pass with 100% statement coverage
- ✅ No code changes required — the API surface (`createTransport`, `sendMail`, `close`, `Attachment` type) is stable across v6→v7